### PR TITLE
Updated Vue require to import

### DIFF
--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -6,7 +6,8 @@
 
 require('./bootstrap');
 
-window.Vue = require('vue');
+import Vue from 'vue';
+window.Vue = Vue;
 
 /**
  * The following block of code may be used to automatically register your


### PR DESCRIPTION
This addresses issue #10, which pointed out that Vue was still being pulled in with the require function.