### PR TITLE
Add macro check on ui:auth command

### DIFF
--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -46,6 +46,10 @@ class AuthCommand extends Command
      */
     public function handle()
     {
+        if (static::hasMacro($this->argument('type'))) {
+            return call_user_func(static::$macros[$this->argument('type')], $this);
+        }
+        
         if (! in_array($this->argument('type'), ['bootstrap'])) {
             throw new InvalidArgumentException('Invalid preset.');
         }


### PR DESCRIPTION
Exactly like in the `ui` command this provides an easy way to extend the functionality with other `ui:auth` scaffolding types e.g. for inertiajs https://github.com/inertiajs/inertia-laravel/issues/47