### PR TITLE
Remove X-CSRF-TOKEN header from Axios instance

### DIFF
--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -24,20 +24,6 @@ window.axios = require('axios');
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**
- * Next we will register the CSRF Token as a common header with Axios so that
- * all outgoing HTTP requests automatically have it attached. This is just
- * a simple convenience so we don't have to attach every token manually.
- */
-
-let token = document.head.querySelector('meta[name="csrf-token"]');
-
-if (token) {
-    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
-} else {
-    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
-}
-
-/**
  * Echo exposes an expressive API for subscribing to channels and listening
  * for events that are broadcast by Laravel. Echo and event broadcasting
  * allows your team to easily build robust real-time web applications.


### PR DESCRIPTION
Since the X-CSRF-TOKEN header was [recently removed](https://github.com/laravel/laravel/pull/5083) from Laravel's core `bootstrap.js`, it probably makes sense to remove it from UI as well.