### PR TITLE
Add Bootstrap CSS CDN link in layout blade file.

### DIFF
--- a/src/Auth/bootstrap-stubs/layouts/app.stub
+++ b/src/Auth/bootstrap-stubs/layouts/app.stub
@@ -9,6 +9,8 @@
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" 
+        integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
 


### PR DESCRIPTION
This change adds bootstrap CSS CDN link in Layout. Without Bootstrap CSS, login, register page breaks down as current app.css file doesn't have any CSS link imported.

**Benefit**: If this PR accepted, after adding the repo in Laravel project, when user will visit the `login`/`register` page, the page will not be broken.