### PR TITLE
Add missing semicolon to avoid unnecessary diff

### DIFF
--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -29,7 +29,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
  * allows your team to easily build robust real-time web applications.
  */
 
-// import Echo from 'laravel-echo'
+// import Echo from 'laravel-echo';
 
 // window.Pusher = require('pusher-js');
 


### PR DESCRIPTION
The default laravel's [bootstrap.js](https://github.com/laravel/laravel/blob/master/resources/js/bootstrap.js#L19) file has a semicolon in the Echo import statement and even though the missing one in the scaffolded file is not strictly required, it causes an unnecessary diff if it is not there when the scaffolding happens.

![image](https://user-images.githubusercontent.com/5356595/66274662-746a7780-e846-11e9-86d4-164dcf9e6ea4.png)

