### PR TITLE
Update resolve-url-loader dependency constraint

### DIFF
--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -31,7 +31,7 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            'resolve-url-loader' => '2.3.1',
+            'resolve-url-loader' => '^2.3.1',
             'sass' => '^1.20.1',
             'sass-loader' => '7.*',
             'vue' => '^2.5.17',


### PR DESCRIPTION
As the `laravel/laravel`'s [package.json](https://github.com/laravel/laravel/blob/master/package.json#L17) file, it now uses the caret constraint instead of a fixed dependency version