### PR TITLE
Add auth.passwords.confirm to exported views

### DIFF
--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -31,6 +31,7 @@ class AuthCommand extends Command
      */
     protected $views = [
         'auth/login.stub' => 'auth/login.blade.php',
+        'auth/passwords/confirm.stub' => 'auth/passwords/confirm.blade.php',
         'auth/passwords/email.stub' => 'auth/passwords/email.blade.php',
         'auth/passwords/reset.stub' => 'auth/passwords/reset.blade.php',
         'auth/register.stub' => 'auth/register.blade.php',
@@ -49,7 +50,7 @@ class AuthCommand extends Command
         if (static::hasMacro($this->argument('type'))) {
             return call_user_func(static::$macros[$this->argument('type')], $this);
         }
-        
+
         if (! in_array($this->argument('type'), ['bootstrap'])) {
             throw new InvalidArgumentException('Invalid preset.');
         }


### PR DESCRIPTION
When scaffolding auth, copy the new password confirm stub. Currently you get an error unless you manually copy the template: https://flareapp.io/share/W7z1K2Pw#F48

References laravel/framework#30214 and laravel/ui#34
