### PR TITLE
Change the specified time until re-authentication

### DIFF
--- a/src/Auth/bootstrap-stubs/auth/passwords/confirm.stub
+++ b/src/Auth/bootstrap-stubs/auth/passwords/confirm.stub
@@ -9,7 +9,7 @@
 
                 <div class="card-body">
                     {{ __('Please confirm your password before continuing.') }}
-                    {{ __('We won\'t ask for your password again for a few hours.') }}
+                    {{ __('We won\'t ask for your password again for a certain amount of time.') }}
 
                     <form method="POST" action="{{ route('password.confirm') }}">
                         @csrf

--- a/src/Auth/bootstrap-stubs/auth/passwords/confirm.stub
+++ b/src/Auth/bootstrap-stubs/auth/passwords/confirm.stub
@@ -9,7 +9,6 @@
 
                 <div class="card-body">
                     {{ __('Please confirm your password before continuing.') }}
-                    {{ __('We won\'t ask for your password again for a certain amount of time.') }}
 
                     <form method="POST" action="{{ route('password.confirm') }}">
                         @csrf


### PR DESCRIPTION
Since the re-authentication timeout is configurable by the user (as described in [laravel/framework#30214](https://github.com/laravel/framework/pull/30214)), I don't think we should hard code "a few hours" in the template.

Therefore, I now opted for "a certain amount of time", however let me know if you come across something more suitable.
