### PR TITLE
checking is_array before array_key_exists in order to use in php7.2

### DIFF
--- a/src/Presets/Preset.php
+++ b/src/Presets/Preset.php
@@ -37,7 +37,7 @@ class Preset
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 
         $packages[$configurationKey] = static::updatePackageArray(
-            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [],
+            is_array($packages) ? array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [] : [],
             $configurationKey
         );
 


### PR DESCRIPTION
<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
