### PR TITLE
[2.x] No forms auth routes option

### DIFF
--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -14,30 +14,34 @@ class AuthRouteMethods
     {
         return function ($options) {
             // Authentication Routes...
-            $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-            $this->post('login', 'Auth\LoginController@login');
+            if (! $options['noforms'] ?? false) {
+                $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+            }
+            $this->post('login', 'Auth\LoginController@login')->name('login');
             $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
             // Registration Routes...
             if ($options['register'] ?? true) {
-                $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-                $this->post('register', 'Auth\RegisterController@register');
+                if (! $options['noforms'] ?? false) {
+                    $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+                }
+                $this->post('register', 'Auth\RegisterController@register')->name('register');
             }
 
             // Password Reset Routes...
             if ($options['reset'] ?? true) {
-                $this->resetPassword();
+                $this->resetPassword($options['noforms'] ?? false);
             }
 
             // Password Confirmation Routes...
             if ($options['confirm'] ??
                 class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
-                $this->confirmPassword();
+                $this->confirmPassword($options['noforms'] ?? false);
             }
 
             // Email Verification Routes...
             if ($options['verify'] ?? false) {
-                $this->emailVerification();
+                $this->emailVerification($options['noforms'] ?? false);
             }
         };
     }
@@ -47,12 +51,16 @@ class AuthRouteMethods
      *
      * @return void
      */
-    public function resetPassword()
+    public function resetPassword($noForms = false)
     {
-        return function () {
-            $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.request');
+        return function () use ($noForms) {
+            if (! $noForms) {
+                $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')
+                    ->name('password.request');
+                $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')
+                    ->name('password.reset');
+            }
             $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-            $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
             $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
         };
     }
@@ -62,10 +70,13 @@ class AuthRouteMethods
      *
      * @return void
      */
-    public function confirmPassword()
+    public function confirmPassword($noForms = false)
     {
-        return function () {
-            $this->get('password/confirm', 'Auth\ConfirmPasswordController@showConfirmForm')->name('password.confirm');
+        return function () use ($noForms) {
+            if (! $noForms) {
+                $this->get('password/confirm', 'Auth\ConfirmPasswordController@showConfirmForm')
+                    ->name('password.confirm');
+            }
             $this->post('password/confirm', 'Auth\ConfirmPasswordController@confirm');
         };
     }
@@ -75,10 +86,12 @@ class AuthRouteMethods
      *
      * @return void
      */
-    public function emailVerification()
+    public function emailVerification($noForms)
     {
-        return function () {
-            $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
+        return function () use ($noForms) {
+            if (! $noForms) {
+                $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
+            }
             $this->get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')->name('verification.verify');
             $this->post('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
         };


### PR DESCRIPTION
What:

Adds an option to not include the auth routes that are purely for showing the forms for login/registering etc.

How:

```
Auth::routes(['noforms' = > true']);
```

Why:

Laravel 7 routes will be able to handle XHR/JSON requests making the forms redundant for some applications that want to be an SPA etc.