### PR TITLE
[1.x] feat(Vue) add token in bootstap, update version and fix import ES6

### DIFF
--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -34,7 +34,7 @@ class Vue extends Preset
             'resolve-url-loader' => '^2.3.1',
             'sass' => '^1.20.1',
             'sass-loader' => '7.*',
-            'vue' => '^2.5.17',
+            'vue' => '^2.6.10',
             'vue-template-compiler' => '^2.6.10',
         ] + Arr::except($packages, [
             '@babel/preset-react',

--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -23,6 +23,12 @@ window.axios = require('axios');
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
+// let token = document.head.querySelector('meta[name="csrf-token"]');
+
+// if(token) {
+//   window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+// }
+
 /**
  * Echo exposes an expressive API for subscribing to channels and listening
  * for events that are broadcast by Laravel. Echo and event broadcasting

--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -4,7 +4,7 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap');
+import './bootstrap';
 
 window.Vue = require('vue');
 


### PR DESCRIPTION
Updated vue imported version from 2.5.17 to 2.6.10, new features here: [2.6.10](https://github.com/vuejs/vue/releases/tag/v2.6.10)

It's proposed (by comments) in _bootstrap.js_ the assignment of token in axios headers.

**Fixed:** in _app.js_

> File is a CommonJS module; it may be converted to an ES6 module.ts(80001)

<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
