### PR TITLE
update echo parameter

### DIFF
--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -37,5 +37,5 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 //     broadcaster: 'pusher',
 //     key: process.env.MIX_PUSHER_APP_KEY,
 //     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
-//     encrypted: true
+//     forceTLS: true
 // });


### PR DESCRIPTION
Sync default bootstrap.js with the stub provided here.

> The `encrypted` option for Pusher is deprecated and replaced with `forceTLS`.

More info: https://github.com/laravel/laravel/pull/5159