### PR TITLE
[2.x] Avoid duplicate route names when using multiple guards

### DIFF
--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -15,13 +15,13 @@ class AuthRouteMethods
         return function ($options = []) {
             // Authentication Routes...
             $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-            $this->post('login', 'Auth\LoginController@login');
+            $this->post('login', 'Auth\LoginController@login')->name('login.action');
             $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
             // Registration Routes...
             if ($options['register'] ?? true) {
                 $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-                $this->post('register', 'Auth\RegisterController@register');
+                $this->post('register', 'Auth\RegisterController@register')->name('register.action');
             }
 
             // Password Reset Routes...
@@ -66,7 +66,7 @@ class AuthRouteMethods
     {
         return function () {
             $this->get('password/confirm', 'Auth\ConfirmPasswordController@showConfirmForm')->name('password.confirm');
-            $this->post('password/confirm', 'Auth\ConfirmPasswordController@confirm');
+            $this->post('password/confirm', 'Auth\ConfirmPasswordController@confirm')->name('password.confirm.action');
         };
     }
 


### PR DESCRIPTION
I have multi guard app which have separate login route group for "admin" with name prefix "admin.".
Unfortunately since there are few routes in `Laravel\Ui\AuthRouteMethods` which are not named it causes error on `php artisan route:cache`
![image](https://user-images.githubusercontent.com/6100872/76431887-e24d3900-63ba-11ea-8e7f-17dfcaf1e750.png)

To get better idea why that is, here is what `php artisan route:list` returns:
![image](https://user-images.githubusercontent.com/6100872/76432240-5e478100-63bb-11ea-858d-54338b5eca65.png)

This PR just gives name to the unnamed routes which should not cause any backwards incompatibilities unless somebody uses the same route names (which is unlikely if they use `Auth::routes();` anyway).