### PR TITLE
[2.x] Return CSRF token on Ajax login

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -112,7 +112,7 @@ trait AuthenticatesUsers
         }
 
         return $request->wantsJson()
-                    ? new Response('', 204)
+                    ? new Response(csrf_token(), 200)
                     : redirect()->intended($this->redirectPath());
     }
 


### PR DESCRIPTION
If you do login via Ajax, the current CSRF token that is in the head gets unauthorized. By returning the CSRF on the login request we can easily update it:

```
const loginResponse = await axios.post('/login', {
  email,
  password
});

document.querySelector('meta[name="csrf-token"]').content = loginResponse.data;
```

Then, subsequent Ajax requests using libraries like Apollo client won't break. 

This can easily explain/fix all the issues people are having with Airlock and the CSRF token mismatch.

