### PR TITLE
[2.x] Add \Illuminate\View\View as return value in doc-blocks

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -14,7 +14,7 @@ trait AuthenticatesUsers
     /**
      * Show the application's login form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showLoginForm()
     {

--- a/auth-backend/ConfirmsPasswords.php
+++ b/auth-backend/ConfirmsPasswords.php
@@ -12,7 +12,7 @@ trait ConfirmsPasswords
     /**
      * Display the password confirmation view.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showConfirmForm()
     {

--- a/auth-backend/RegistersUsers.php
+++ b/auth-backend/RegistersUsers.php
@@ -14,7 +14,7 @@ trait RegistersUsers
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showRegistrationForm()
     {

--- a/auth-backend/SendsPasswordResetEmails.php
+++ b/auth-backend/SendsPasswordResetEmails.php
@@ -12,7 +12,7 @@ trait SendsPasswordResetEmails
     /**
      * Display the form to request a password reset link.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function showLinkRequestForm()
     {

--- a/auth-backend/VerifiesEmails.php
+++ b/auth-backend/VerifiesEmails.php
@@ -15,7 +15,7 @@ trait VerifiesEmails
      * Show the email verification notice.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\View\View
      */
     public function show(Request $request)
     {


### PR DESCRIPTION
In this PR I updated the @returns for multiple functions in de auth-backend folder. This because they don't correctly represent the value that's being returned.

In 4/5 cases there is a view() returned which actually returns \Illuminate\View\View.