### PR TITLE
Fix for Login API

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -103,7 +103,8 @@ trait AuthenticatesUsers
      */
     protected function sendLoginResponse(Request $request)
     {
-        $request->session()->regenerate();
+        if (!$request->is('api/*'))
+            $request->session()->regenerate();
 
         $this->clearLoginAttempts($request);
 


### PR DESCRIPTION
When calling 'Auth\LoginController@login' from API router it encounter  "message": "Session store not set on request.", "exception": "RuntimeException" error due to missing web middlewares.

This is a quick fix, interested to know if there is a better solution.

This will help users to build simple auth API using existing laravel auth which is currently throwing errors when login through API route.
