### PR TITLE
[2.x] Confirm controller overwrite

### DIFF
--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -113,10 +113,13 @@ class AuthCommand extends Command
     {
         $this->callSilent('ui:controllers');
 
-        file_put_contents(
-            app_path('Http/Controllers/HomeController.php'),
-            $this->compileControllerStub()
-        );
+        $controller = app_path('Http/Controllers/HomeController.php');
+
+        if (file_exists($controller) && ! $this->option('force')) {
+            if ($this->confirm("The [HomeController.php] already exists. Do you want to replace it?")) {
+                file_put_contents($controller, $this->compileControllerStub());
+            }
+        }
 
         file_put_contents(
             base_path('routes/web.php'),

--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -116,7 +116,7 @@ class AuthCommand extends Command
         $controller = app_path('Http/Controllers/HomeController.php');
 
         if (file_exists($controller) && ! $this->option('force')) {
-            if ($this->confirm("The [HomeController.php] already exists. Do you want to replace it?")) {
+            if ($this->confirm("The [HomeController.php] file already exists. Do you want to replace it?")) {
                 file_put_contents($controller, $this->compileControllerStub());
             }
         }


### PR DESCRIPTION
This will prevent the `HomeController` from being overwritten when scaffolding the auth files.

Closes https://github.com/laravel/ui/issues/94