### PR TITLE
[2.x] Remove method_exists check

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -33,11 +33,7 @@ trait AuthenticatesUsers
     {
         $this->validateLogin($request);
 
-        // If the class is using the ThrottlesLogins trait, we can automatically throttle
-        // the login attempts for this application. We'll key this by the username and
-        // the IP address of the client making these requests into this application.
-        if (method_exists($this, 'hasTooManyLoginAttempts') &&
-            $this->hasTooManyLoginAttempts($request)) {
+        if ($this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
 
             return $this->sendLockoutResponse($request);


### PR DESCRIPTION
I've removed the `method_exists` check for `hasTooManyLoginAttempts` since the trait `AuthenticatesUsers` is using the `ThrottlesLogins` trait.

Therefore, any class that uses the `AuthenticatesUsers` trait will always have the `hasTooManyLoginAttempts` method available as well.
