### PR TITLE
[2.x] Removing v-pre on bootstrap app layout

### DIFF
--- a/src/Auth/bootstrap-stubs/layouts/app.stub
+++ b/src/Auth/bootstrap-stubs/layouts/app.stub
@@ -50,7 +50,7 @@
                             @endif
                         @else
                             <li class="nav-item dropdown">
-                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{ Auth::user()->name }} <span class="caret"></span>
                                 </a>
 


### PR DESCRIPTION
I believe that 'v-pre` is only necessary with vue scaffolding therefore shoud not be present on bootstrap layouts.
