### PR TITLE
Fix confirm controller overwrite

### DIFF
--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -119,6 +119,8 @@ class AuthCommand extends Command
             if ($this->confirm("The [HomeController.php] file already exists. Do you want to replace it?")) {
                 file_put_contents($controller, $this->compileControllerStub());
             }
+        } else {
+            file_put_contents($controller, $this->compileControllerStub());
         }
 
         file_put_contents(


### PR DESCRIPTION
The PR #95 introduced an issue; 
The `HomeController.php` is no longer created when it doesn't exists on a fresh Laravel project.


This fix the issue I initially saw on stackoverflow https://stackoverflow.com/questions/61501766/laravel-7-auth-no-homecontroller

