### PR TITLE
[2.x] Use RouteServiceProvider constant when registering the /home route

### DIFF
--- a/src/Auth/stubs/routes.stub
+++ b/src/Auth/stubs/routes.stub
@@ -1,4 +1,4 @@
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index')->name('home');
+Route::get(RouteServiceProvider::HOME, 'HomeController@index')->name('home');


### PR DESCRIPTION
In line with this pull request (https://github.com/laravel/laravel/pull/5301), I'd like to suggest updating the Laravel UI package so when using --auth, the default route /home added registers using `RouteServiceProvider::HOME` instead of `'/home'`, so you would only then have a single place to update for consistency.