### PR TITLE
[2.x] Defer tag causes flicker in Bootstrap components

### DIFF
--- a/src/Auth/bootstrap-stubs/layouts/app.stub
+++ b/src/Auth/bootstrap-stubs/layouts/app.stub
@@ -9,9 +9,6 @@
 
     <title>{{ config('app.name', 'Laravel') }}</title>
 
-    <!-- Scripts -->
-    <script src="{{ asset('js/app.js') }}" defer></script>
-
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
@@ -76,5 +73,8 @@
             @yield('content')
         </main>
     </div>
+
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
I am suggesting to move the javascript tag to just before the closing body tag and remove defer.

The reason I am suggesting this change is because when you have javascript in the head with defer it causes Bootstrap components like buttons and badges to flicker whenever a link is clicked.

I've verified this is an issue in multiple projects and this is for sure the source of the problem.

<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
