### PR TITLE
Suggestion for update to AuthRouteMethods

### DIFF
--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -13,10 +13,16 @@ class AuthRouteMethods
     public function auth()
     {
         return function ($options = []) {
-            // Authentication Routes...
-            $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-            $this->post('login', 'Auth\LoginController@login');
-            $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+            // Login Routes...
+            if ($options['login'] ?? true) {
+                $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+                $this->post('login', 'Auth\LoginController@login');
+            }
+            
+            // Logout Routes...
+            if ($options['logout'] ?? true) {
+                $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+            }
 
             // Registration Routes...
             if ($options['register'] ?? true) {


### PR DESCRIPTION
I appreciate all the work you and the team are doing. When upgrading from Laravel >= 5.7 and now 6.x to 7.x some of the methods and classes have changed. I kept getting a login and logout conflict with our web routes. I had to dig down and find this reference. The $options attribute is a great way to turn on/off routes but it seems a little incomplete. There are so many more suggestion dealing with following existing controller method naming conventions, should the options be in an auth configuration, etc. but wanted to focus on a low hanging fruit (this use case).

Use case: Web route name "login" and "logout" is defined but still want to use auth routes "registration" and "reset". Was able to turn on/off everything except "login" and "logout" routes.

I could see this being implemented in a minor version without backwards compatibility issues. Please consider.

Thanks,
Brant

<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
