### PR TITLE
Allow user to define redirect path after logout

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -173,7 +173,7 @@ trait AuthenticatesUsers
 
         return $request->wantsJson()
             ? new Response('', 204)
-            : redirect('/');
+            : redirect()->intended($this->redirectAfterLogoutPath());
     }
 
     /**

--- a/auth-backend/RedirectsUsers.php
+++ b/auth-backend/RedirectsUsers.php
@@ -17,4 +17,18 @@ trait RedirectsUsers
 
         return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
     }
+
+    /**
+     * Get the post logout redirect path.
+     *
+     * @return string
+     */
+    public function redirectAfterLogoutPath()
+    {
+        if (method_exists($this, 'redirectAfterLogoutTo')) {
+            return $this->redirectAfterLogoutTo();
+        }
+
+        return property_exists($this, 'redirectAfterLogoutTo') ? $this->redirectAfterLogoutTo : '/';
+    }
 }

--- a/stubs/Auth/LoginController.stub
+++ b/stubs/Auth/LoginController.stub
@@ -29,6 +29,13 @@ class LoginController extends Controller
     protected $redirectTo = RouteServiceProvider::HOME;
 
     /**
+     * Where to redirect users after logout.
+     *
+     * @var string
+     */
+    protected $redirectAfterLogoutTo = RouteServiceProvider::HOME;
+
+    /**
      * Create a new controller instance.
      *
      * @return void


### PR DESCRIPTION
Adding `redirectAfterLogoutTo` in `LoginController` with necessary changes to allow a user to define where to redirect after successful logout just like `redirectTo` path which redirects after login. This makes it significantly easier to define where to send user after logout instead of adding checking in the default route file.
