### PR TITLE
let lower level scopes hash the password

### DIFF
--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -67,7 +67,7 @@ class RegisterController extends Controller
         return User::create([
             'name' => $data['name'],
             'email' => $data['email'],
-            'password' => Hash::make($data['password']),
+            'password' => $data['password'],
         ]);
     }
 }


### PR DESCRIPTION
The `RegisterController::create(array $data)` method hashes the user password before delegating the user creation logic to the `User` model
```
    protected function create(array $data)
    {
        return User::create([
            'name' => $data['name'],
            'email' => $data['email'],
            'password' => Hash::make($data['password']),
        ]);
    }
```

It looks like the `User` model also applies its own hashing logic internally, leading to a double hashing of the password.
When a users attempt to login after registration, the login attempts fail.