### PR TITLE
[3.x] Fetch reset token explicitly.

### DIFF
--- a/auth-backend/ResetsPasswords.php
+++ b/auth-backend/ResetsPasswords.php
@@ -24,8 +24,10 @@ trait ResetsPasswords
      * @param  string|null  $token
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function showResetForm(Request $request, $token = null)
+    public function showResetForm(Request $request)
     {
+        $token = $request->route()->parameter('token');
+        
         return view('auth.passwords.reset')->with(
             ['token' => $token, 'email' => $request->email]
         );


### PR DESCRIPTION
With a route like the following, `$token` in `showResetForm(Request $request, $token = null)` will give the value of `{subdomain}` and not `{token}` because route parameters are injected based on their order.

```
Route::group(['domain' => '{subdomain}.example.com'], function () {
    $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
});
```

This pull request proposes that the token is explicitly fetched by name to avoid this.

I have submitted this to the master branch because it could break sites that do not use `Auth::routes()` where `{token}` is the standard parameter name.