### PR TITLE
[2.x] Use proper json responses

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
@@ -99,7 +99,7 @@ trait AuthenticatesUsers
      * Send the response after the user was authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     protected function sendLoginResponse(Request $request)
     {
@@ -112,7 +112,7 @@ trait AuthenticatesUsers
         }
 
         return $request->wantsJson()
-                    ? new Response('', 204)
+                    ? new JsonResponse([], 204)
                     : redirect()->intended($this->redirectPath());
     }
 
@@ -157,7 +157,7 @@ trait AuthenticatesUsers
      * Log the user out of the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     public function logout(Request $request)
     {
@@ -172,7 +172,7 @@ trait AuthenticatesUsers
         }
 
         return $request->wantsJson()
-            ? new Response('', 204)
+            ? new JsonResponse([], 204)
             : redirect('/');
     }
 

--- a/auth-backend/ConfirmsPasswords.php
+++ b/auth-backend/ConfirmsPasswords.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 trait ConfirmsPasswords
 {
@@ -32,7 +32,7 @@ trait ConfirmsPasswords
         $this->resetPasswordConfirmationTimeout($request);
 
         return $request->wantsJson()
-                    ? new Response('', 204)
+                    ? new JsonResponse([], 204)
                     : redirect()->intended($this->redirectPath());
     }
 

--- a/auth-backend/RegistersUsers.php
+++ b/auth-backend/RegistersUsers.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 trait RegistersUsers
@@ -25,7 +25,7 @@ trait RegistersUsers
      * Handle a registration request for the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     public function register(Request $request)
     {
@@ -40,7 +40,7 @@ trait RegistersUsers
         }
 
         return $request->wantsJson()
-                    ? new Response('', 201)
+                    ? new JsonResponse([], 201)
                     : redirect($this->redirectPath());
     }
 

--- a/auth-backend/SendsPasswordResetEmails.php
+++ b/auth-backend/SendsPasswordResetEmails.php
@@ -82,7 +82,9 @@ trait SendsPasswordResetEmails
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $response
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\RedirectResponse
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {

--- a/auth-backend/VerifiesEmails.php
+++ b/auth-backend/VerifiesEmails.php
@@ -4,8 +4,8 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Events\Verified;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 trait VerifiesEmails
 {
@@ -15,7 +15,7 @@ trait VerifiesEmails
      * Show the email verification notice.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response|\Illuminate\View\View
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
      */
     public function show(Request $request)
     {
@@ -28,7 +28,7 @@ trait VerifiesEmails
      * Mark the authenticated user's email address as verified.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
@@ -44,7 +44,7 @@ trait VerifiesEmails
 
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
-                        ? new Response('', 204)
+                        ? new JsonResponse([], 204)
                         : redirect($this->redirectPath());
         }
 
@@ -57,7 +57,7 @@ trait VerifiesEmails
         }
 
         return $request->wantsJson()
-                    ? new Response('', 204)
+                    ? new JsonResponse([], 204)
                     : redirect($this->redirectPath())->with('verified', true);
     }
 
@@ -76,20 +76,20 @@ trait VerifiesEmails
      * Resend the email verification notification.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     public function resend(Request $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
-                        ? new Response('', 204)
+                        ? new JsonResponse([], 204)
                         : redirect($this->redirectPath());
         }
 
         $request->user()->sendEmailVerificationNotification();
 
         return $request->wantsJson()
-                    ? new Response('', 202)
+                    ? new JsonResponse([], 202)
                     : back()->with('resent', true);
     }
 }


### PR DESCRIPTION
Empty strings aren't valid JSON. These changes make sure that valid JSON is sent back even though the responses are empty.

Fixes https://github.com/laravel/ui/issues/137