### PR TITLE
[2.x] Add namespace check to Auth routes

### DIFF
--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -13,38 +13,42 @@ class AuthRouteMethods
     public function auth()
     {
         return function ($options = []) {
-            // Login Routes...
-            if ($options['login'] ?? true) {
-                $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-                $this->post('login', 'Auth\LoginController@login');
-            }
-            
-            // Logout Routes...
-            if ($options['logout'] ?? true) {
-                $this->post('logout', 'Auth\LoginController@logout')->name('logout');
-            }
+            $namespace = class_exists($this->prependGroupNamespace('Auth\LoginController')) ? null : 'App\Http\Controllers';
 
-            // Registration Routes...
-            if ($options['register'] ?? true) {
-                $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-                $this->post('register', 'Auth\RegisterController@register');
-            }
+            $this->group(['namespace' => $namespace], function() {
+                // Login Routes...
+                if ($options['login'] ?? true) {
+                    $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
+                    $this->post('login', 'Auth\LoginController@login');
+                }
 
-            // Password Reset Routes...
-            if ($options['reset'] ?? true) {
-                $this->resetPassword();
-            }
+                // Logout Routes...
+                if ($options['logout'] ?? true) {
+                    $this->post('logout', 'Auth\LoginController@logout')->name('logout');
+                }
 
-            // Password Confirmation Routes...
-            if ($options['confirm'] ??
-                class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
-                $this->confirmPassword();
-            }
+                // Registration Routes...
+                if ($options['register'] ?? true) {
+                    $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+                    $this->post('register', 'Auth\RegisterController@register');
+                }
 
-            // Email Verification Routes...
-            if ($options['verify'] ?? false) {
-                $this->emailVerification();
-            }
+                // Password Reset Routes...
+                if ($options['reset'] ?? true) {
+                    $this->resetPassword();
+                }
+
+                // Password Confirmation Routes...
+                if ($options['confirm'] ??
+                    class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
+                    $this->confirmPassword();
+                }
+
+                // Email Verification Routes...
+                if ($options['verify'] ?? false) {
+                    $this->emailVerification();
+                }
+            });
         };
     }
 

--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -15,7 +15,7 @@ class AuthRouteMethods
         return function ($options = []) {
             $namespace = class_exists($this->prependGroupNamespace('Auth\LoginController')) ? null : 'App\Http\Controllers';
 
-            $this->group(['namespace' => $namespace], function() {
+            $this->group(['namespace' => $namespace], function() use($options) {
                 // Login Routes...
                 if ($options['login'] ?? true) {
                     $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');


### PR DESCRIPTION
When removing the Route default namespace (as is default in Laravel 8), the Auth routes will break. This is the case for new Laravel 8 apps, but also when you want to upgrade to match the new defaults.

I understand this package is now deprecated, but if this is the only change it might be worth considering to give users the time to upgrade/change/get comfortable to Jetstream and let it stabilize/grow a bit first.

This checks if the Class with namespace exists. If it doesn't, it adds the default namespace, to compensate for https://github.com/laravel/laravel/commit/58a98efb86c0c0a819e333a52eccf2a7de652f15#diff-b467cc786635bd6945b17726282f1c64

Fixes #138 #141 #142