### PR TITLE
[2.x] Fix Bootstrap preset

### DIFF
--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -14,6 +14,7 @@ class Bootstrap extends Preset
     public static function install()
     {
         static::updatePackages();
+        static::updateWebpackConfiguration();
         static::updateSass();
         static::updateBootstrapping();
         static::removeNodeModules();
@@ -31,7 +32,19 @@ class Bootstrap extends Preset
             'bootstrap' => '^4.0.0',
             'jquery' => '^3.2',
             'popper.js' => '^1.12',
+            'sass' => '^1.15.2',
+            'sass-loader' => '^8.0.0',
         ] + $packages;
+    }
+
+    /**
+     * Update the Webpack configuration.
+     *
+     * @return void
+     */
+    protected static function updateWebpackConfiguration()
+    {
+        copy(__DIR__.'/react-stubs/webpack.mix.js', base_path('webpack.mix.js'));
     }
 
     /**

--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -44,7 +44,7 @@ class Bootstrap extends Preset
      */
     protected static function updateWebpackConfiguration()
     {
-        copy(__DIR__.'/react-stubs/webpack.mix.js', base_path('webpack.mix.js'));
+        copy(__DIR__.'/bootstrap-stubs/webpack.mix.js', base_path('webpack.mix.js'));
     }
 
     /**

--- a/src/Presets/bootstrap-stubs/webpack.mix.js
+++ b/src/Presets/bootstrap-stubs/webpack.mix.js
@@ -1,0 +1,15 @@
+const mix = require('laravel-mix');
+
+/*
+ |--------------------------------------------------------------------------
+ | Mix Asset Management
+ |--------------------------------------------------------------------------
+ |
+ | Mix provides a clean, fluent API for defining some Webpack build steps
+ | for your Laravel application. By default, we are compiling the Sass
+ | file for the application as well as bundling up all the JS files.
+ |
+ */
+
+mix.js('resources/js/app.js', 'public/js')
+    .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
This fixes an issue with Laravel 8 where the bootstrap preset still needs sass to compile its CSS assets.

Fixes https://github.com/laravel/ui/issues/144