### PR TITLE
Fix: Class 'App\User' not found

### DIFF
--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
-use App\User;
+use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;


### PR DESCRIPTION
Fix the default path for the User model.
When I run a new project from version 8 I found this problem.
`Class 'App\User' not found`
