### PR TITLE
Update home route registration

### DIFF
--- a/src/Auth/stubs/routes.stub
+++ b/src/Auth/stubs/routes.stub
@@ -1,4 +1,4 @@
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');


### PR DESCRIPTION
As Laravel 8.x has done away with the default namespace, the `HomeController` needs to reference the full class path.

Have also swapped to tuple notation, as this is how the docs are demonstrating registration.