### PR TITLE
[3.x] Readme: correct link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ While Laravel does not dictate which JavaScript or CSS pre-processors you use, i
 
 ## Official Documentation
 
-Documentation can be found on the [Laravel website](https://laravel.com/docs/frontend).
+Documentation can be found on the [Laravel website](https://laravel.com/docs/7.x/frontend).
 
 ## Contributing
 


### PR DESCRIPTION
Laravel/UI Readme doesn't contain the documentation on how to use it, it only has link to the documentation which currently says "Page not found", cause there's no "Frontend" page in Laravel 8.x anymore.

I realize that Laravel/UI is not actively maintained, but for those who do want to use it, I think working link to the documentation will be useful.