### PR TITLE
[3.x] Update PHPDoc comment

### DIFF
--- a/auth-backend/ResetsPasswords.php
+++ b/auth-backend/ResetsPasswords.php
@@ -21,7 +21,6 @@ trait ResetsPasswords
      * If no token is present, display the link request form.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string|null  $token
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function showResetForm(Request $request)


### PR DESCRIPTION
The `$token` parameter is removed. #130 