### PR TITLE
[3.x] presets: modernize the js syntax

### DIFF
--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -1,4 +1,5 @@
-window._ = require('lodash');
+import lodash from 'lodash';
+window._ = lodash;
 
 /**
  * We'll load jQuery and the Bootstrap jQuery plugin which provides support
@@ -6,12 +7,10 @@ window._ = require('lodash');
  * code may be modified to fit the specific needs of your application.
  */
 
-try {
-    window.Popper = require('popper.js').default;
-    window.$ = window.jQuery = require('jquery');
-
-    require('bootstrap');
-} catch (e) {}
+import jQuery from 'jquery';
+window.$ = window.jQuery = jQuery;
+import 'popper.js';
+import 'bootstrap';
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
@@ -19,7 +18,8 @@ try {
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
-window.axios = require('axios');
+import axios from 'axios';
+window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -31,7 +31,8 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 // import Echo from 'laravel-echo';
 
-// window.Pusher = require('pusher-js');
+// import Pusher from 'pusher-js';
+// window.Pusher = Pusher;
 
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',

--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -6,7 +6,8 @@
 
 require('./bootstrap');
 
-window.Vue = require('vue');
+import Vue from 'vue';
+window.Vue = Vue;
 
 /**
  * The following block of code may be used to automatically register your


### PR DESCRIPTION
Hi, @driesvints 

* Use modern ES6 syntax to import modules
* No need for `window.Popper`, since bootstrap.js can auto resolve it
* Remove the try/catch, we can not use `import` inside try block. 
