### PR TITLE
Adapting to different supported User's model locations

### DIFF
--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
-use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -60,14 +59,30 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      *
      * @param  array  $data
-     * @return \App\Models\User
+     * @return User
      */
     protected function create(array $data)
     {
-        return User::create([
+        $userNamespace = $this->resolveUserModelNamespace();
+
+        return $userNamespace::create([
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    /**
+     * Resolves the correct User's model namespace.
+     *
+     * @return string
+     */
+    protected function resolveUserModelNamespace()
+    {
+        if (is_dir(app_path('Models'))) {
+            return 'App\\Models\\User';
+        }
+
+        return 'App\\User';
     }
 }


### PR DESCRIPTION
I just find out that Laravel UI does not automatically adapt to the different supported locations for the User's model.

Currently, Laravel UI assumes that the User model will always be inside the Models folder, but that is not always the case AND Laravel currently supports that out of the box.

With this solution, the RegisterController will automatically adapt the User namespace according to the existence of the Models folder.

I hope it looks like a good solution but I am open to modifying it if needed,.

Thanks, guys!

PS: I skipped opening an issue, as it is just a small piece of code, so I am ok if it is not accepted.

PS2: If it is OK for you, if you can add the "hacktoberfest-accepted" label would be great 😋