### PR TITLE
[1.x] Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|^7.2.5|^8.0",
+        "php": "^7.1.3|^8.0",
         "illuminate/console": "~5.8|^6.0",
         "illuminate/filesystem": "~5.8|^6.0",
         "illuminate/support": "~5.8|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -10,23 +10,14 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^7.2.5|^8.0",
         "illuminate/console": "~5.8|^6.0",
         "illuminate/filesystem": "~5.8|^6.0",
         "illuminate/support": "~5.8|^6.0"
     },
-    "require-dev": {
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.0"
-    },
     "autoload": {
         "psr-4": {
             "Laravel\\Ui\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Laravel\\Ui\\Tests\\": "tests/"
         }
     },
     "config": {


### PR DESCRIPTION
As mentioned in [#178](https://github.com/laravel/ui/pull/178#issuecomment-719910329)

@driesvints I removed the `require-dev` and `autoload-dev` block as there are no tests yet. (The composer.json file is aligned with the 3.x branch now). If I should revert this change, let me know