### PR TITLE
Adding readonly attribute on reset password

### DIFF
--- a/src/Auth/bootstrap-stubs/auth/passwords/reset.stub
+++ b/src/Auth/bootstrap-stubs/auth/passwords/reset.stub
@@ -17,7 +17,7 @@
                             <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
 
                             <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus>
+                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus readonly>
 
                                 @error('email')
                                     <span class="invalid-feedback" role="alert">


### PR DESCRIPTION
Adding readonly attribute on `reset.stub`

Description: prevents from user to change email address.

Example:
![image](https://user-images.githubusercontent.com/48077864/99480825-d5de9e80-2993-11eb-9748-e36b713163fd.png)
