### PR TITLE
[3.x] Upgrade Vue 2 to Vue 3

### DIFF
--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -31,11 +31,12 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
+            '@vue/compiler-sfc' => '^3.0.5',
             'resolve-url-loader' => '^2.3.1',
             'sass' => '^1.20.1',
             'sass-loader' => '^8.0.0',
-            'vue' => '^2.5.17',
-            'vue-template-compiler' => '^2.6.10',
+            'vue' => '^3.0.5',
+            'vue-loader' => '^16.1.2',
         ] + Arr::except($packages, [
             '@babel/preset-react',
             'react',

--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -6,7 +6,8 @@
 
 require('./bootstrap');
 
-window.Vue = require('vue').default;
+import { createApp } from 'vue';
+const app = createApp({});
 
 /**
  * The following block of code may be used to automatically register your
@@ -19,7 +20,7 @@ window.Vue = require('vue').default;
 // const files = require.context('./', true, /\.vue$/i)
 // files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 
-Vue.component('example-component', require('./components/ExampleComponent.vue').default);
+app.component('example-component', require('./components/ExampleComponent.vue').default);
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to
@@ -27,6 +28,4 @@ Vue.component('example-component', require('./components/ExampleComponent.vue').
  * or customize the JavaScript scaffolding to fit your unique needs.
  */
 
-const app = new Vue({
-    el: '#app',
-});
+app.mount('#app');

--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -18,7 +18,7 @@ const app = createApp({});
  */
 
 // const files = require.context('./', true, /\.vue$/i)
-// files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
+// files.keys().map(key => app.component(key.split('/').pop().split('.')[0], files(key).default))
 
 app.component('example-component', require('./components/ExampleComponent.vue').default);
 


### PR DESCRIPTION
Upgrades the Vue dependencies from Vue 2.x to Vue 3.x. I matched them to the ones used in the other starter kits.

I chose to initialize ```const app``` separate from mounting it, so that the current example for registering components individually or automatically (if the end user chooses to uncomment those lines) would still work as close to the original as possible.

I don't think this will be as much of a breaking change compared to the other way of registering components in Vue 3.x:

```
import { createApp } from 'vue';
import ExampleComponent from './components/ExampleComponent.vue';

createApp({
   components:  {
       ExampleComponent
   }
}).mount('#app');
```