### PR TITLE
[3.x] Use trans helper instead of Lang Facade

### DIFF
--- a/auth-backend/ThrottlesLogins.php
+++ b/auth-backend/ThrottlesLogins.php
@@ -6,7 +6,6 @@ use Illuminate\Auth\Events\Lockout;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
@@ -53,7 +52,7 @@ trait ThrottlesLogins
         );
 
         throw ValidationException::withMessages([
-            $this->username() => [Lang::get('auth.throttle', [
+            $this->username() => [trans('auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ])],


### PR DESCRIPTION
To make it uniform with other files in the directory, we need to use trans instead of Lang::get