### PR TITLE
Pass validated data to create method

### DIFF
--- a/auth-backend/RegistersUsers.php
+++ b/auth-backend/RegistersUsers.php
@@ -29,9 +29,9 @@ trait RegistersUsers
      */
     public function register(Request $request)
     {
-        $this->validator($request->all())->validate();
+        $validated = $this->validator($request->all())->validate();
 
-        event(new Registered($user = $this->create($request->all())));
+        event(new Registered($user = $this->create($validated)));
 
         $this->guard()->login($user);
 


### PR DESCRIPTION
This PR means to prevent some devs living on the edge 😎🏄‍♂️ from getting caught offguard 😴😱. Mostly for convenience.

I was creating a user the way I usually do (`protected $guarded = [];` + rely on validated data) in `RegisterController@create`:
```php
protected function create(array $data)
{
    // Do some stuff.

    return User::create($data);
}
```

Turns out I was assuming the `$data` array passed to it was the validated data from the validator right above:
```php
protected function validator(array $data)
{
    return Validator::make($data, [
        'name' => ['required', 'string', 'max:255'],
        'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
        'password' => ['required', 'string', 'min:8', 'confirmed'],
    ]);
}
```

But it wasn't. My current workaround is running validation again:
```php
protected function create(array $data)
{
    $validated = $this->validator($data)->validated();

    // Do some stuff.

    return User::create($data);
}
```

So **this PR will pass the validated data to the create method** instead. I imagine there's a case to be made for having access to the original data, and if so, I could consider changing the PR to pass it as well. 