### PR TITLE
Update dependencies

### DIFF
--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -29,11 +29,11 @@ class Bootstrap extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            'bootstrap' => '^4.0.0',
-            'jquery' => '^3.2',
-            'popper.js' => '^1.12',
-            'sass' => '^1.15.2',
-            'sass-loader' => '^8.0.0',
+            'bootstrap' => '^4.6.0',
+            'jquery' => '^3.6',
+            'popper.js' => '^1.16.1',
+            'sass' => '^1.32.11',
+            'sass-loader' => '^11.0.1',
         ] + $packages;
     }
 

--- a/src/Presets/React.php
+++ b/src/Presets/React.php
@@ -31,9 +31,9 @@ class React extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            '@babel/preset-react' => '^7.0.0',
-            'react' => '^16.2.0',
-            'react-dom' => '^16.2.0',
+            '@babel/preset-react' => '^7.13.13',
+            'react' => '^17.0.2',
+            'react-dom' => '^17.0.2',
         ] + Arr::except($packages, ['vue', 'vue-template-compiler']);
     }
 

--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -31,11 +31,11 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            'resolve-url-loader' => '^2.3.1',
-            'sass' => '^1.20.1',
-            'sass-loader' => '^8.0.0',
-            'vue' => '^2.5.17',
-            'vue-template-compiler' => '^2.6.10',
+            'resolve-url-loader' => '^3.1.2',
+            'sass' => '^1.32.11',
+            'sass-loader' => '^11.0.1',
+            'vue' => '^2.6.12',
+            'vue-template-compiler' => '^2.6.12',
         ] + Arr::except($packages, [
             '@babel/preset-react',
             'react',


### PR DESCRIPTION
Updating dependencies due to a high-level vulnerability in object-path.
It occurs in the Vue preset and can be audited with `npm audit`.
See: bholloway/resolve-url-loader#170