### PR TITLE
Json response patch

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -138,9 +138,15 @@ trait AuthenticatesUsers
      */
     protected function sendFailedLoginResponse(Request $request)
     {
-        throw ValidationException::withMessages([
+        $data = [
             $this->username() => [trans('auth.failed')],
-        ]);
+        ];
+        
+        if(! $request->wantsJson()) {
+            throw ValidationException::withMessages($data);
+        }
+
+        return new JsonResponse($data) ;
     }
 
     /**

--- a/auth-backend/ThrottlesLogins.php
+++ b/auth-backend/ThrottlesLogins.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Http\Request;
@@ -50,13 +51,19 @@ trait ThrottlesLogins
         $seconds = $this->limiter()->availableIn(
             $this->throttleKey($request)
         );
-
-        throw ValidationException::withMessages([
+        $data = [
             $this->username() => [trans('auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ])],
-        ])->status(Response::HTTP_TOO_MANY_REQUESTS);
+        ];
+        
+        if(! $request->wantsJson()) {
+            throw ValidationException::withMessages($data)
+                ->status(Response::HTTP_TOO_MANY_REQUESTS);
+        }
+        
+        return new JsonResponse($data, Response::HTTP_TOO_MANY_REQUESTS);
     }
 
     /**


### PR DESCRIPTION
Hello there,

Today, I wanted to make a full AJAX auth with the default Laravel authentification system. I just realized that no tests were made to determine whether a request needed a JSON response in `sendFailedLoginResponse()` and `sendLockoutResponse()` methods.
So I made this little change, I think it could help many people.

If it already exists in another way, sorry for your time.

Pythagus