### PR TITLE
Update sendLockoutResponse return type (docblock) for static analysis / IDE help 

### DIFF
--- a/auth-backend/ThrottlesLogins.php
+++ b/auth-backend/ThrottlesLogins.php
@@ -41,7 +41,7 @@ trait ThrottlesLogins
      * Redirect the user after determining they are locked out.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return void
+     * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Illuminate\Validation\ValidationException
      */


### PR DESCRIPTION
### Problem
PHPStorm & PhpStan show error on ```return $this->sendLockoutResponse($request);``` in a custom LoginController.

### Solution
This PR updates the DocBlock => Return type to return same value used in laravel/framework => AuthenticatesUsers Trait, which is how it is used + what is expected.