### PR TITLE
Set `password_confirmed_at` on login

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -44,6 +44,7 @@ trait AuthenticatesUsers
         }
 
         if ($this->attemptLogin($request)) {
+            $request->session()->put('auth.password_confirmed_at', time());
             return $this->sendLoginResponse($request);
         }
 

--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -45,6 +45,7 @@ trait AuthenticatesUsers
 
         if ($this->attemptLogin($request)) {
             $request->session()->put('auth.password_confirmed_at', time());
+
             return $this->sendLoginResponse($request);
         }
 


### PR DESCRIPTION
The current behaviour is such that when an unauthenticated user is accessing a confirmation-protected route, they are first asked to log in and then instantly asked to confirm the password. That confuses users and also is redundant as they just entered the password.

I have made the most straightforward solution here — explicitly set the `password_confirmed_at` timestamp as the user logs in.