### PR TITLE
Add support for .well-known/change-password

### DIFF
--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -64,6 +64,9 @@ class AuthRouteMethods
             $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
             $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
             $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
+            $this->get('.well-known/change-password', function(){
+                return redirect()->route('password.request');
+            });
         };
     }
 


### PR DESCRIPTION
<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adds automatic support for well-known change password URLs as documented at https://web.dev/change-password-url/

This will help all end visitors who use password managers by making the password reset functionality more seamless.
The new route follows the standard options so is only active if password resets are enabled.

The main reset page and general functions are unchanged, this only adds a redirect that automated systems may already probe.