### PR TITLE
Call parent::__construct() in controllers

### DIFF
--- a/src/Auth/stubs/controllers/HomeController.stub
+++ b/src/Auth/stubs/controllers/HomeController.stub
@@ -13,6 +13,8 @@ class HomeController extends Controller
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->middleware('auth');
     }
 

--- a/stubs/Auth/ConfirmPasswordController.stub
+++ b/stubs/Auth/ConfirmPasswordController.stub
@@ -35,6 +35,8 @@ class ConfirmPasswordController extends Controller
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->middleware('auth');
     }
 }

--- a/stubs/Auth/LoginController.stub
+++ b/stubs/Auth/LoginController.stub
@@ -35,6 +35,8 @@ class LoginController extends Controller
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->middleware('guest')->except('logout');
     }
 }

--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -38,6 +38,8 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->middleware('guest');
     }
 

--- a/stubs/Auth/VerificationController.stub
+++ b/stubs/Auth/VerificationController.stub
@@ -35,6 +35,8 @@ class VerificationController extends Controller
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->middleware('auth');
         $this->middleware('signed')->only('verify');
         $this->middleware('throttle:6,1')->only('verify', 'resend');


### PR DESCRIPTION
Hi,

This PR will add a call to parent::__construct() in all controllers stubs.

All the controllers in this package extends the App\Http\Controller which could have a controller defined. Without the parent::__construct() the base controller constructor will not be executed.

I personally have a constructor in my App\Http\Controller and I had this problem.
In my case I share the authenticated user with all views within the base controller using a middleware.
