### PR TITLE
[3.x] Replace removeSpecialCharacters method with Str Helper Equivalent

### DIFF
--- a/auth-backend/ThrottlesLogins.php
+++ b/auth-backend/ThrottlesLogins.php
@@ -89,7 +89,7 @@ trait ThrottlesLogins
      */
     protected function throttleKey(Request $request)
     {
-        return $this->removeSpecialCharacters(Str::lower($request->input($this->username())).'|'.$request->ip());
+        return Str::transliterate(Str::lower($request->input($this->username())).'|'.$request->ip());
     }
 
     /**
@@ -120,87 +120,5 @@ trait ThrottlesLogins
     public function decayMinutes()
     {
         return property_exists($this, 'decayMinutes') ? $this->decayMinutes : 1;
-    }
-
-    /**
-     * Remove special characters that may allow users to bypass rate limiting.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function removeSpecialCharacters($key)
-    {
-        $values = [
-            'ⓐ' => 'a',
-            'ⓑ' => 'b',
-            'ⓒ' => 'c',
-            'ⓓ' => 'd',
-            'ⓔ' => 'e',
-            'ⓕ' => 'f',
-            'ⓖ' => 'g',
-            'ⓗ' => 'h',
-            'ⓘ' => 'i',
-            'ⓙ' => 'j',
-            'ⓚ' => 'k',
-            'ⓛ' => 'l',
-            'ⓜ' => 'm',
-            'ⓝ' => 'n',
-            'ⓞ' => 'o',
-            'ⓟ' => 'p',
-            'ⓠ' => 'q',
-            'ⓡ' => 'r',
-            'ⓢ' => 's',
-            'ⓣ' => 't',
-            'ⓤ' => 'u',
-            'ⓥ' => 'v',
-            'ⓦ' => 'w',
-            'ⓧ' => 'x',
-            'ⓨ' => 'y',
-            'ⓩ' => 'z',
-            '①' => '1',
-            '②' => '2',
-            '③' => '3',
-            '④' => '4',
-            '⑤' => '5',
-            '⑥' => '6',
-            '⑦' => '7',
-            '⑧' => '8',
-            '⑨' => '9',
-            '⑩' => '10',
-            '⑪' => '11',
-            '⑫' => '12',
-            '⑬' => '13',
-            '⑭' => '14',
-            '⑮' => '15',
-            '⑯' => '16',
-            '⑰' => '17',
-            '⑱' => '18',
-            '⑲' => '19',
-            '⑳' => '20',
-            '⓪' => '0',
-            '⓵' => '1',
-            '⓶' => '2',
-            '⓷' => '3',
-            '⓸' => '4',
-            '⓹' => '5',
-            '⓺' => '6',
-            '⓻' => '7',
-            '⓼' => '8',
-            '⓽' => '9',
-            '⓾' => '10',
-            '⓫' => '11',
-            '⓬' => '12',
-            '⓭' => '13',
-            '⓮' => '14',
-            '⓯' => '15',
-            '⓰' => '16',
-            '⓱' => '17',
-            '⓲' => '18',
-            '⓳' => '19',
-            '⓴' => '20',
-            '⓿' => '0',
-        ];
-
-        return strtr($key, $values);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3|^8.0",
         "illuminate/console": "^8.42|^9.0",
         "illuminate/filesystem": "^8.42|^9.0",
-        "illuminate/support": "^8.42|^9.0",
+        "illuminate/support": "^8.82|^9.0",
         "illuminate/validation": "^8.42|^9.0"
     },
     "require-dev": {

--- a/tests/AuthBackend/ThrottleLoginsTest.php
+++ b/tests/AuthBackend/ThrottleLoginsTest.php
@@ -11,32 +11,6 @@ class ThrottleLoginsTest extends TestCase
 {
     /**
      * @test
-     * @dataProvider specialCharacterProvider
-     */
-    public function it_can_replace_special_characters(string $value, string $expected): void
-    {
-        $throttle = $this->getMockForTrait(ThrottlesLogins::class);
-        $reflection = new \ReflectionClass($throttle);
-        $method = $reflection->getMethod('removeSpecialCharacters');
-        $method->setAccessible(true);
-
-        $this->assertSame($expected, $method->invoke($throttle, $value));
-    }
-
-    public function specialCharacterProvider(): array
-    {
-        return [
-            ['ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ', 'abcdefghijklmnopqrstuvwxyz'],
-            ['⓪①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳', '01234567891011121314151617181920'],
-            ['⓵⓶⓷⓸⓹⓺⓻⓼⓽⓾', '12345678910'],
-            ['⓿⓫⓬⓭⓮⓯⓰⓱⓲⓳⓴', '011121314151617181920'],
-            ['abcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxyz'],
-            ['0123456789', '0123456789'],
-        ];
-    }
-
-    /**
-     * @test
      * @dataProvider emailProvider
      */
     public function it_can_generate_throttle_key(string $email, string $expectedEmail): void


### PR DESCRIPTION
Update on work for this PR: https://github.com/laravel/ui/pull/216

Now that transliteration exists in Core, I've replaced the existing method in UI with its Str helper equivalent.

Not sure if you also want to bump the other core requirements for consistency sake.