### PR TITLE
Add max password length

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -71,7 +71,7 @@ trait AuthenticatesUsers
     {
         $request->validate([
             $this->username() => 'required|string',
-            'password' => 'required|string',
+            'password' => 'required|string|max:72',
         ]);
     }
 

--- a/auth-backend/ConfirmsPasswords.php
+++ b/auth-backend/ConfirmsPasswords.php
@@ -55,7 +55,7 @@ trait ConfirmsPasswords
     protected function rules()
     {
         return [
-            'password' => 'required|password',
+            'password' => 'required|password|max:72',
         ];
     }
 

--- a/auth-backend/ResetsPasswords.php
+++ b/auth-backend/ResetsPasswords.php
@@ -70,7 +70,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password' => ['required', 'max:72', 'confirmed', Rules\Password::defaults()],
         ];
     }
 

--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -52,7 +52,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', 'min:8', 'max:72', 'confirmed'],
         ]);
     }
 


### PR DESCRIPTION
### Why?
Apparently, `bcrypt` has a maximum input length of 72 bytes. Any input provided to it with a longer length will be truncated. 
reference: https://security.stackexchange.com/questions/39849/does-bcrypt-have-a-maximum-password-length

That's why if someone sets any password longer than 72 characters, will only store the password based on the first 72 characters. I've checked it by the following code:
```php
use Illuminate\Support\Str;
use Illuminate\Support\Facades\Hash;


$hashedPassword = bcrypt(Str::repeat('a', 71));
Hash::check(Str::repeat('a', 71), $hashedPassword); // true
Hash::check(Str::repeat('a', 70), $hashedPassword); // false

$hashedPassword = bcrypt(Str::repeat('a', 73));
Hash::check(Str::repeat('a', 73), $hashedPassword); // true
Hash::check(Str::repeat('a', 72), $hashedPassword); // true
```

You can see, no matter how long the password is, the `bcrypt` is only using the first 72 characters to create the hash. 
So, it's better to have a max length validation on the password field, so that it won't be an unexpected behavior for the user.

### Changes
- Added `max:72` length validation to registration, login, config, reset password requests.
- Updated test to check the validation is working. 