### PR TITLE
Update ConfirmsPasswords.php

### DIFF
--- a/auth-backend/ConfirmsPasswords.php
+++ b/auth-backend/ConfirmsPasswords.php
@@ -55,7 +55,7 @@ trait ConfirmsPasswords
     protected function rules()
     {
         return [
-            'password' => 'required|password',
+            'password' => 'required|current_password:web',
         ];
     }
 


### PR DESCRIPTION
password rule was renamed to current_password with the intention of removing it in Laravel 9. Please use the Current Password rule instead.

<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
