### PR TITLE
Update 2014_10_12_100000_create_password_resets_table.php

### DIFF
--- a/stubs/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/stubs/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePasswordResetsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -29,4 +29,4 @@ class CreatePasswordResetsTable extends Migration
     {
         Schema::dropIfExists('password_resets');
     }
-}
+};


### PR DESCRIPTION
Laravel version 9.x uses an anonymous class migrate, but this version uses the usual method for migration.