### PR TITLE
Fix the issue of none existing directory

### DIFF
--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -66,6 +66,10 @@ class Bootstrap extends Preset
      */
     protected static function updateBootstrapping()
     {
+         if (!(new Filesystem)->exists(resource_path('js'))) {
+            (new Filesystem)->makeDirectory(resource_path('js'));
+        }
+        
         copy(__DIR__.'/bootstrap-stubs/bootstrap.js', resource_path('js/bootstrap.js'));
     }
 }


### PR DESCRIPTION
If we have the `js` directory in the `resources` the `bootstrap` file will be created successfully BUT what if the directory does not exist? The `copy(C:\...\resources\js/bootstrap.js): Failed to open stream: No such file or directory` exception will be triggered as happened WITH me So, this condition solve this issue, by checking if the directory was not existed then create it for me.
