### PR TITLE
Fixed missing validation error for password

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -144,6 +144,7 @@ trait AuthenticatesUsers
     {
         throw ValidationException::withMessages([
             $this->username() => [trans('auth.failed')],
+            'password' => [trans('auth.failed')]
         ]);
     }
 

--- a/tests/AuthBackend/AuthenticatesUsersTest.php
+++ b/tests/AuthBackend/AuthenticatesUsersTest.php
@@ -70,6 +70,9 @@ class AuthenticatesUsersTest extends TestCase
             'email' => [
                 'These credentials do not match our records.',
             ],
+            'password' => [
+                'These credentials do not match our records.',
+            ],
         ], $response->exception->errors());
     }
 
@@ -90,6 +93,9 @@ class AuthenticatesUsersTest extends TestCase
         $this->assertInstanceOf(ValidationException::class, $response->exception);
         $this->assertSame([
             'email' => [
+                'These credentials do not match our records.',
+            ],
+            'password' => [
                 'These credentials do not match our records.',
             ],
         ], $response->exception->errors());


### PR DESCRIPTION
When a user tries to login and enters the wrong password, the authentication fails and the `sendFailedLoginResponse` is triggered. Previously this function only throws a `ValidationException` with the `email` field, causing the error message of `auth.failed` which in default Laravel app is "These credentials do not match our records." to only appear below the email input field, and does not show any invalidity in the UI in the password field, even if the password field is what was incorrect (I observed this when using Bootstrap scaffolding). As a result this would make the user feel that the incorrect input was the email address rather than the password.

This PR is an attempt to fix this issue by adding the `password` field to the `ValidationException`. By doing this, the error bag contains the `password` field and appropriate invalid message and UI elements are shown. 

Tests are edited accordingly.