### PR TITLE
Fixes AuthenticatesUsers always force remember me

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -84,7 +84,7 @@ trait AuthenticatesUsers
     protected function attemptLogin(Request $request)
     {
         return $this->guard()->attempt(
-            $this->credentials($request), $request->filled('remember')
+            $this->credentials($request), $request->boolean('remember')
         );
     }
 


### PR DESCRIPTION
`$request->boolean()` is available on the minimum version supported by `laravel/ui`: https://github.com/laravel/framework/blob/v8.42.0/src/Illuminate/Http/Concerns/InteractsWithInput.php#L272-L284

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>