### PR TITLE
[4.x] Vite 3

### DIFF
--- a/src/Presets/React.php
+++ b/src/Presets/React.php
@@ -35,7 +35,10 @@ class React extends Preset
             '@vitejs/plugin-react' => '^2.0.0',
             'react' => '^17.0.2',
             'react-dom' => '^17.0.2',
-        ] + Arr::except($packages, ['@vitejs/plugin-vue', 'vue']);
+        ] + Arr::except($packages, [
+            '@vitejs/plugin-vue',
+            'vue'
+        ]);
     }
 
     /**

--- a/src/Presets/React.php
+++ b/src/Presets/React.php
@@ -33,7 +33,7 @@ class React extends Preset
     {
         return [
             '@babel/preset-react' => '^7.13.13',
-            '@vitejs/plugin-react' => '^1.3.2',
+            '@vitejs/plugin-react' => '^2.0.0',
             'react' => '^17.0.2',
             'react-dom' => '^17.0.2',
         ] + Arr::except($packages, ['@vitejs/plugin-vue', 'vue']);

--- a/src/Presets/React.php
+++ b/src/Presets/React.php
@@ -32,7 +32,6 @@ class React extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            '@babel/preset-react' => '^7.13.13',
             '@vitejs/plugin-react' => '^2.0.0',
             'react' => '^17.0.2',
             'react-dom' => '^17.0.2',

--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -32,7 +32,6 @@ class Vue extends Preset
     {
         return [
             '@vitejs/plugin-vue' => '^3.0.1',
-            'sass' => '^1.32.11',
             'vue' => '^3.2.37',
         ] + Arr::except($packages, [
             '@vitejs/plugin-react',

--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -32,11 +32,9 @@ class Vue extends Preset
     {
         return [
             '@vitejs/plugin-vue' => '^3.0.1',
-            'resolve-url-loader' => '^3.1.2',
             'sass' => '^1.32.11',
             'vue' => '^3.2.37',
         ] + Arr::except($packages, [
-            '@babel/preset-react',
             '@vitejs/plugin-react',
             'react',
             'react-dom',

--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -31,7 +31,7 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            '@vitejs/plugin-vue' => '^2.3.3',
+            '@vitejs/plugin-vue' => '^3.0.1',
             'resolve-url-loader' => '^3.1.2',
             'sass' => '^1.32.11',
             'vue' => '^3.2.37',

--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -28,7 +28,7 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',
 //     key: import.meta.env.VITE_PUSHER_APP_KEY,
-//     wsHost: import.meta.env.VITE_PUSHER_HOST ?? `ws-${import.meta.env.VITE_PUSHER_CLUSTER}.pusher.com`,
+//     wsHost: import.meta.env.VITE_PUSHER_HOST ?? `ws-${import.meta.env.VITE_PUSHER_APP_CLUSTER}.pusher.com`,
 //     wsPort: import.meta.env.VITE_PUSHER_PORT ?? 80,
 //     wssPort: import.meta.env.VITE_PUSHER_PORT ?? 443,
 //     forceTLS: (import.meta.env.VITE_PUSHER_SCHEME ?? 'https') === 'https',

--- a/src/Presets/bootstrap-stubs/vite.config.js
+++ b/src/Presets/bootstrap-stubs/vite.config.js
@@ -3,9 +3,12 @@ import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/sass/app.scss',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/sass/app.scss',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
     ],
 });

--- a/src/Presets/react-stubs/vite.config.js
+++ b/src/Presets/react-stubs/vite.config.js
@@ -4,10 +4,13 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/sass/app.scss',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/sass/app.scss',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
         react(),
     ],
 });

--- a/src/Presets/vue-stubs/vite.config.js
+++ b/src/Presets/vue-stubs/vite.config.js
@@ -4,10 +4,13 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            'resources/sass/app.scss',
-            'resources/js/app.js',
-        ]),
+        laravel({
+            input: [
+                'resources/sass/app.scss',
+                'resources/js/app.js',
+            ],
+            refresh: true,
+        }),
         vue({
             template: {
                 transformAssetUrls: {


### PR DESCRIPTION
This PR updates `master` with the following changes:

* Updates the Vue and React plugin for Vite 3 support.
* Updates an env var to match `laravel/laravel` (https://github.com/laravel/laravel/pull/5929)
* Enables the Blade refreshing feature to match `laravel/laravel`.
* Removes some unnecessary webpack packages.