### PR TITLE
Drop support for Laravel 8 and PHP 7.3 & 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
-        laravel: [^8.0, ^9.0]
-        exclude:
-          - php: 7.3
-            laravel: ^9.0
-          - php: 7.4
-            laravel: ^9.0
+        php: ['8.0', 8.1]
+        laravel: [^9.0]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/console": "^8.42|^9.0",
-        "illuminate/filesystem": "^8.42|^9.0",
-        "illuminate/support": "^8.82|^9.0",
-        "illuminate/validation": "^8.42|^9.0"
+        "php": "^8.0",
+        "illuminate/console": "^9.0",
+        "illuminate/filesystem": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/validation": "^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.23|^7.0"
+        "orchestra/testbench": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
