### PR TITLE
Fix the route compatibility

### DIFF
--- a/src/Auth/bootstrap-stubs/auth/verify.stub
+++ b/src/Auth/bootstrap-stubs/auth/verify.stub
@@ -16,7 +16,7 @@
 
                     {{ __('Before proceeding, please check your email for a verification link.') }}
                     {{ __('If you did not receive the email') }},
-                    <form class="d-inline" method="POST" action="{{ route('verification.resend') }}">
+                    <form class="d-inline" method="POST" action="{{ route('verification.send') }}">
                         @csrf
                         <button type="submit" class="btn btn-link p-0 m-0 align-baseline">{{ __('click here to request another') }}</button>.
                     </form>

--- a/src/AuthRouteMethods.php
+++ b/src/AuthRouteMethods.php
@@ -90,7 +90,7 @@ class AuthRouteMethods
         return function () {
             $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
             $this->get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')->name('verification.verify');
-            $this->post('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
+            $this->post('email/resend', 'Auth\VerificationController@resend')->name('verification.send');
         };
     }
 }


### PR DESCRIPTION
This PR fixes the issue of `Route [verification.resend] not defined.` as Laravel [says](https://laravel.com/docs/9.x/verification#resending-the-verification-email), when we need to resend email verification, we must define a new route with `verification.send` name, So we must change `verification.resend` to `verification.send`.