### PR TITLE
Allow using login for API routes without session

### DIFF
--- a/auth-backend/AuthenticatesUsers.php
+++ b/auth-backend/AuthenticatesUsers.php
@@ -107,7 +107,9 @@ trait AuthenticatesUsers
      */
     protected function sendLoginResponse(Request $request)
     {
-        $request->session()->regenerate();
+        if ($request->hasSession()) {
+            $request->session()->regenerate();
+        }
 
         $this->clearLoginAttempts($request);
 
@@ -167,9 +169,11 @@ trait AuthenticatesUsers
     {
         $this->guard()->logout();
 
-        $request->session()->invalidate();
+        if ($request->hasSession()) {
+            $request->session()->invalidate();
 
-        $request->session()->regenerateToken();
+            $request->session()->regenerateToken();
+        }
 
         if ($response = $this->loggedOut($request)) {
             return $response;


### PR DESCRIPTION
It is useful to use the same `AuthenticatesUsers` trait for login via API as for login in the browser, because the trait provides things like throttling and validation.

The problem is similar to the discussion in #208 - API routes may not have a session.

This PR adds `if ($request->hasSession()) {` the same as the comments in #208 suggest.

This also replaces #90 properly.