### PR TITLE
[4.x] update deprecated globing mechanism

### DIFF
--- a/src/Presets/vue-stubs/app.js
+++ b/src/Presets/vue-stubs/app.js
@@ -26,7 +26,7 @@ app.component('example-component', ExampleComponent);
  * Eg. ./components/ExampleComponent.vue -> <example-component></example-component>
  */
 
-// Object.entries(import.meta.globEager('./**/*.vue')).forEach(([path, definition]) => {
+// Object.entries(import.meta.glob('./**/*.vue', { eager: true })).forEach(([path, definition]) => {
 //     app.component(path.split('/').pop().replace(/\.\w+$/, ''), definition.default);
 // });
 


### PR DESCRIPTION
The current suggestion was deprecated with Vite 3.

See: https://vitejs.dev/guide/migration.html#import-meta-glob

<img width="742" alt="Screen Shot 2022-09-06 at 5 16 45 pm" src="https://user-images.githubusercontent.com/24803032/188571125-60cfd9ee-f289-4c16-bff8-f3f17d1ab973.png">
