### PR TITLE
fix: changing validator return type in phpdoc

### DIFF
--- a/stubs/Auth/RegisterController.stub
+++ b/stubs/Auth/RegisterController.stub
@@ -45,7 +45,7 @@ class RegisterController extends Controller
      * Get a validator for an incoming registration request.
      *
      * @param  array  $data
-     * @return \Illuminate\Contracts\Validation\Validator
+     * @return \Illuminate\Support\Facades\Validator
      */
     protected function validator(array $data)
     {


### PR DESCRIPTION
I think the validator return type is wrong in the phpdoc. So we should change the currently used return type.