### PR TITLE
Remove lodash import

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,4 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "illuminate/validation": "^9.21|^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0"
+        "orchestra/testbench": "^7.0|^8.0",
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Presets/bootstrap-stubs/bootstrap.js
+++ b/src/Presets/bootstrap-stubs/bootstrap.js
@@ -1,6 +1,3 @@
-import _ from 'lodash';
-window._ = _;
-
 import 'bootstrap';
 
 /**


### PR DESCRIPTION
Lodash was removed from the Laravel skeleton in v10.
There is no usage of lodash in the `ui` package.

related issue: https://github.com/laravel/framework/issues/46128