### PR TITLE
Change logout link to button

### DIFF
--- a/src/Auth/bootstrap-stubs/layouts/app.stub
+++ b/src/Auth/bootstrap-stubs/layouts/app.stub
@@ -55,11 +55,9 @@
                                 </a>
 
                                 <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                                    <a class="dropdown-item" href="{{ route('logout') }}"
-                                       onclick="event.preventDefault();
-                                                     document.getElementById('logout-form').submit();">
+                                    <button class="dropdown-item" form="logout-form">
                                         {{ __('Logout') }}
-                                    </a>
+                                    </button>
 
                                     <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
                                         @csrf


### PR DESCRIPTION
Using a button instead of link will make the element submit the form even if JS is disabled or a strict CSP blocks inline JS (which was my case). Visually I did not observe any differences from the previous control.

I think there is no benefit in this being a link as the link features (like opening it in a new tab or copying the URL) can only lead to a "405 Method Not Allowed" error.

The `form` attribute is not supported on IE and old (pre-chromium) versions of Edge. If that's a concern, I can change it to

```html
<form id="logout-form" action="{{ route('logout') }}" method="POST">
    @csrf
    <button class="dropdown-item" form="logout-form">
        {{ __('Logout') }}
    </button>
</form>
```

which appears to have the same appearance. I didn't do that yet because it seems intentional that the control was outside the form.