### PR TITLE
Fix vite resource name

### DIFF
--- a/src/Auth/bootstrap-stubs/layouts/app.stub
+++ b/src/Auth/bootstrap-stubs/layouts/app.stub
@@ -14,7 +14,7 @@
     <link href="https://fonts.bunny.net/css?family=Nunito" rel="stylesheet">
 
     <!-- Scripts -->
-    @vite(['resources/sass/app.scss', 'resources/js/app.js'])
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body>
     <div id="app">


### PR DESCRIPTION
Hello!
The `resources/css/app.css` alias is used throughout the organization: https://github.com/search?q=org%3Alaravel%20%40vite&type=code
Now here too.
