### PR TITLE
[4.x] Fixes defaults on confirm

### DIFF
--- a/src/AuthCommand.php
+++ b/src/AuthCommand.php
@@ -118,7 +118,7 @@ class AuthCommand extends Command
         $controller = app_path('Http/Controllers/HomeController.php');
 
         if (file_exists($controller) && ! $this->option('force')) {
-            if ($this->components->confirm("The [HomeController.php] file already exists. Do you want to replace it?")) {
+            if ($this->components->confirm("The [HomeController.php] file already exists. Do you want to replace it?", true)) {
                 file_put_contents($controller, $this->compileStub('controllers/HomeController'));
             }
         } else {
@@ -128,7 +128,7 @@ class AuthCommand extends Command
         $baseController = app_path('Http/Controllers/Controller.php');
 
         if (file_exists($baseController) && ! $this->option('force')) {
-            if ($this->components->confirm("The [Controller.php] file already exists. Do you want to replace it?")) {
+            if ($this->components->confirm("The [Controller.php] file already exists. Do you want to replace it?", true)) {
                 file_put_contents($baseController, $this->compileStub('controllers/Controller'));
             }
         } else {


### PR DESCRIPTION
This pull request prevents that people accidentally press [enter] without copying the base controller.