### PR TITLE
[4.x] Ensure logout requires authentication

### DIFF
--- a/stubs/Auth/LoginController.stub
+++ b/stubs/Auth/LoginController.stub
@@ -35,5 +35,6 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+        $this->middleware('auth')->only('logout');
     }
 }


### PR DESCRIPTION
Please see: https://github.com/laravel/fortify/pull/536

## laravel/ui specific considerations

This only fixes future installations.

We could throw an unauthenticated exception in the controller so that existing installs get this fix, but I don't love that solution as it wouldn't necessarily match what their apps `Authenticate` middleware does if they have made customisations.

Putting the `auth` middleware on the route in the routes file feels problematic as well as the app may not have an `auth` middleware. Everywhere a middleware is currently referenced is published as a stub so the user has full control.

This doesn't seems like a massive issue, so I feel this "simple" fix is reasonable.