### PR TITLE
Fix '@vitejs/plugin-vue' conflict with laravel 12.X

### DIFF
--- a/src/Presets/Vue.php
+++ b/src/Presets/Vue.php
@@ -31,8 +31,8 @@ class Vue extends Preset
     protected static function updatePackageArray(array $packages)
     {
         return [
-            '@vitejs/plugin-vue' => '^4.5.0',
-            'vue' => '^3.2.37',
+            '@vitejs/plugin-vue' => '^5.2.1',
+            'vue' => '^3.5.13',
         ] + Arr::except($packages, [
             '@vitejs/plugin-react',
             'react',


### PR DESCRIPTION
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree npm error
npm error While resolving: undefined@undefined
npm error Found: vite@6.2.0
npm error node_modules/vite
npm error   dev vite@"^6.0.11" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vite@"^4.0.0 || ^5.0.0" from @vitejs/plugin-vue@4.6.2
npm error node_modules/@vitejs/plugin-vue
npm error   dev @vitejs/plugin-vue@"^4.5.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /home/zohaib/.npm/_logs/2025-02-25T19_00_59_469Z-eresolve-report.txt
npm error A complete log of this run can be found in: /home/zohaib/.npm/_logs/2025-02-25T19_00_59_469Z-debug-0.log

<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
