### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
             laravel: 9
         exclude:
           - php: 8.5
+            laravel: 11
+          - php: 8.5
             laravel: 10
           - php: 8.4
             laravel: 10


### PR DESCRIPTION
<!--
We are not accepting new presets.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As a follow-up to #286 (thanks for the very quick merge), this PR aims to fix tests CI by excluding the irrelevant Laravel 11/PHP 8.5 combination which is failing due to some deprecations.

It also bumps the checkout action version.