### PR TITLE
Update README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Only the latest major version of Laravel UI receives bug fixes. The table below 
 | [1.x](https://github.com/laravel/ui/tree/1.x) | 5.8, 6.x |
 | [2.x](https://github.com/laravel/ui/tree/2.x) | 7.x |
 | [3.x](https://github.com/laravel/ui/tree/3.x) | 8.x, 9.x |
-| [4.x](https://github.com/laravel/ui/tree/4.x) | 9.x, 10.x, 11.x, 12.x |
+| [4.x](https://github.com/laravel/ui/tree/4.x) | 9.x, 10.x, 11.x, 12.x , 13.x |
 
 ### Installation
 


### PR DESCRIPTION
fix: add laravel 13 to compatible list
