### PR TITLE
Fix reusable workflow pin to match granted permissions

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   help-wanted:
-    uses: laravel/.github/.github/workflows/issues.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/issues.yml@c265c45c41ccb723befb7a2b807dffff4595bd39 # main

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   uneditable:
-    uses: laravel/.github/.github/workflows/pull-requests.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/pull-requests.yml@c265c45c41ccb723befb7a2b807dffff4595bd39 # main


### PR DESCRIPTION
The `pull requests` and `issues` workflows call the shared `laravel/.github` reusable workflows pinned to `dd86ce0`.

At that commit the reusable workflows declare `permissions: contents: read` (and `pull-requests: write` for `issues.yml`), but the callers here only grant `pull-requests: write` / `issues: write`. A reusable workflow cannot request a permission the caller didn't grant, so every run fails at startup (`startup_failure`).

This bumps the pin to the current `laravel/.github` main SHA `c265c45`, which was trimmed to require only the scopes the callers already grant — resolving the failure.